### PR TITLE
Update ServiceBusBusFactoryConfiguratorExtensions.cs

### DIFF
--- a/src/Transports/MassTransit.Azure.ServiceBus.Core/ServiceBusBusFactoryConfiguratorExtensions.cs
+++ b/src/Transports/MassTransit.Azure.ServiceBus.Core/ServiceBusBusFactoryConfiguratorExtensions.cs
@@ -18,11 +18,11 @@
         /// <param name="configure">A callback to further configure the service bus</param>
         /// <returns>The service bus host</returns>
         public static void Host(this IServiceBusBusFactoryConfigurator configurator, Uri hostAddress,
-            Action<IServiceBusHostConfigurator> configure)
+            Action<IServiceBusHostConfigurator> configure = null)
         {
             var hostConfigurator = new ServiceBusHostConfigurator(hostAddress);
 
-            configure(hostConfigurator);
+            configure?.Invoke(hostConfigurator);
 
             configurator.Host(hostConfigurator.Settings);
         }


### PR DESCRIPTION
Add null-check for nullable parameter

When using the string overload for connection string, configure parameter is defined as optional.
It then converts it to Uri and passes the default value to the overload which uses configure
That overload assumes it is not null and throws a null reference exception

![image](https://user-images.githubusercontent.com/8672277/135063585-e06d8052-2b6d-4f00-995b-7582777fdc84.png)
